### PR TITLE
Display material amounts as 128-unit stacks in addition to units and bits

### DIFF
--- a/index.html
+++ b/index.html
@@ -153,7 +153,12 @@
 
                 resultHTML += `
                     <div class="slider-container">
-                        <label>${element.name}: <span id="amount${index}">${defaultUnits}</span> Units (<span id="bits${index}">${defaultUnits / 5}</span> bits)</label>
+                        <label>
+                            ${element.name}: 
+                            <span id="amount${index}">${defaultUnits}</span> Units 
+                            (<span id="bits${index}">${defaultUnits / 5}</span> bits) 
+                            (<span id="stacks${index}">${calculateStacks(defaultUnits / 5)}</span>)
+                        </label>
                         <input type="range" min="${minUnits}" max="${maxUnits}" step="5" value="${defaultUnits}" 
                             oninput="updateValues(${index}, this.value, ${goal})">
                     </div>
@@ -172,6 +177,7 @@
         function updateValues(index, value, goal) {
             document.getElementById(`amount${index}`).textContent = value;
             document.getElementById(`bits${index}`).textContent = value / 5;
+            document.getElementById(`stacks${index}`).textContent = calculateStacks(value / 5);
 
             // Recalculate total
             let totalUnits = 0;
@@ -188,6 +194,16 @@
 				totalBitsElement.style.color = "#ffcc00";
 			}
         }
+
+        function calculateStacks(units, stackSize = 128) {
+            let parts = [];
+            while (units >= stackSize) {
+                parts.push(stackSize);
+                units -= stackSize;
+            }
+            if (units > 0) parts.push(units);
+            return parts.join(" + ");
+}
     </script>
 	<div class="credits">Made by <a href="https://github.com/sehvie/alloyer" target="_blank">Sevie</a>! (@sehvie)</div>
 </body>


### PR DESCRIPTION
This QoL update improves usability of the Alloy Calculator by introducing a visual breakdown of material amounts into 128-unit stacks. In addition to showing the total units and bit counts, the UI now reflects how the material can be split into full and partial stacks.

For example, for 1500 units of Molybdochalkos:
_Old_: 
Lead: 1320 Units (264 bits)
Copper: 180 Units (36 bits)

_New_: 
Lead: 1320 Units (264 bits) (128 + 128 + 8)
Copper: 180 Units (36 bits) (36)